### PR TITLE
add sample files for Sql/mysql/postgresql

### DIFF
--- a/src/mysql-secret-django.py
+++ b/src/mysql-secret-django.py
@@ -1,0 +1,19 @@
+import os
+import mysql.connector
+
+host = os.getenv('AZURE_MYSQL_HOST')
+user = os.getenv('AZURE_MYSQL_USER')
+password = os.getenv('AZURE_MYSQL_PASSWORD')
+database = os.getenv('AZURE_MYSQL_DATABASE')
+port = os.getenv('AZURE_MYSQL_PORT')
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': database,
+        'USER': user,
+        'PASSWORD': password,
+        'HOST': host,
+        'PORT': port
+    }
+}

--- a/src/mysql-secret-dotnet-connectionstring.cs
+++ b/src/mysql-secret-dotnet-connectionstring.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Data;
+using MySql.Data.MySqlClient;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        string connectionString = Environment.GetEnvironmentVariable("AZURE_MYSQL_CONNECTIONSTRING");
+        using (MySqlConnection connection = new MySqlConnection(connectionString))
+        {
+            connection.Open();
+            Console.WriteLine("Connection successful!");
+        }
+    }
+}

--- a/src/mysql-secret-go.go
+++ b/src/mysql-secret-go.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+    "database/sql"
+    "fmt"
+    "os"
+
+    _ "github.com/go-sql-driver/mysql"
+)
+
+func main() {
+    connectionString := os.Getenv("AZURE_MYSQL_CONNECTIONSTRING")
+    db, err := sql.Open("mysql", connectionString)
+    if err != nil {
+        panic(err.Error())
+    }
+    defer db.Close()
+
+    err = db.Ping()
+    if err != nil {
+        panic(err.Error())
+    }
+
+    fmt.Println("Connection successful!")
+}

--- a/src/mysql-secret-java.java
+++ b/src/mysql-secret-java.java
@@ -1,0 +1,14 @@
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class Main {
+    public static void main(String[] args) {
+        String connectionString = System.getenv("AZURE_MYSQL_CONNECTIONSTRING");
+        try (Connection connection = DriverManager.getConnection(connectionString)) {
+            System.out.println("Connection successful!");
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/mysql-secret-nodejs.js
+++ b/src/mysql-secret-nodejs.js
@@ -1,0 +1,20 @@
+const mysql = require('mysql');
+
+const connection = mysql.createConnection({
+  host: process.env.AZURE_MYSQL_HOST,
+  user: process.env.AZURE_MYSQL_USER,
+  password: process.env.AZURE_MYSQL_PASSWORD,
+  database: process.env.AZURE_MYSQL_DATABASE,
+  port: process.env.AZURE_MYSQL_PORT,
+  ssl: process.env.AZURE_MYSQL_SSL
+});
+
+connection.connect((err) => {
+  if (err) {
+    console.error('Error connecting to MySQL database: ' + err.stack);
+    return;
+  }
+  console.log('Connected to MySQL database as id ' + connection.threadId);
+});
+
+module.exports = connection;

--- a/src/mysql-secret-php.php
+++ b/src/mysql-secret-php.php
@@ -1,0 +1,19 @@
+<?php
+$host = getenv('AZURE_MYSQL_HOST');
+$username = getenv('AZURE_MYSQL_USER');
+$password = getenv('AZURE_MYSQL_PASSWORD');
+$database = getenv('AZURE_MYSQL_DATABASE');
+$port = getenv('AZURE_MYSQL_PORT');
+$flag = getenv('AZURE_MYSQL_FLAG');
+
+$conn = mysqli_init();
+mysqli_ssl_set($conn,NULL,NULL,NULL,NULL,NULL);
+mysqli_real_connect($conn, $host, $username, $password, $database, $port, NULL, $flag);
+
+if (mysqli_connect_errno($conn)) {
+    die('Failed to connect to MySQL: ' . mysqli_connect_error());
+}
+
+echo 'Connected successfully to MySQL database!';
+mysqli_close($conn);
+?>

--- a/src/mysql-secret-python.py
+++ b/src/mysql-secret-python.py
@@ -1,0 +1,15 @@
+import os
+import mysql.connector
+
+host = os.getenv('AZURE_MYSQL_HOST')
+user = os.getenv('AZURE_MYSQL_USER')
+password = os.getenv('AZURE_MYSQL_PASSWORD')
+database = os.getenv('AZURE_MYSQL_DATABASE')
+port = os.getenv('AZURE_MYSQL_PORT')
+
+cnx = mysql.connector.connect(user=user, password=password,
+                              host=host,
+                              database=database,
+                              port=port)
+
+cnx.close()

--- a/src/mysql-secret-ruby.rb
+++ b/src/mysql-secret-ruby.rb
@@ -1,0 +1,12 @@
+require 'mysql2'
+require 'dotenv/load'
+
+client = Mysql2::Client.new(
+  host: ENV['AZURE_MYSQL_HOST'],
+  username: ENV['AZURE_MYSQL_USER'],
+  password: ENV['AZURE_MYSQL_PASSWORD'],
+  database: ENV['AZURE_MYSQL_DATABASE'],
+  sslca: ENV['AZURE_MYSQL_SSLMODE']
+)
+
+client.close

--- a/src/mysql-secret-springboot.java
+++ b/src/mysql-secret-springboot.java
@@ -1,0 +1,32 @@
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import javax.sql.DataSource;
+
+@SpringBootApplication
+public class Application {
+
+    @Autowired
+    private DataSourceProperties dataSourceProperties;
+
+    @Bean
+    @Primary
+    @ConfigurationProperties(prefix = "spring.datasource")
+    public DataSource dataSource() {
+        return DataSourceBuilder.create()
+                .url(dataSourceProperties.getUrl())
+                .username(dataSourceProperties.getUsername())
+                .password(dataSourceProperties.getPassword())
+                .build();
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/src/postgresql-secret-django.py
+++ b/src/postgresql-secret-django.py
@@ -1,0 +1,13 @@
+import os
+import dj_database_url
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'HOST': os.environ['AZURE_POSTGRESQL_HOST'],
+        'NAME': os.environ['AZURE_POSTGRESQL_NAME'],
+        'USER': os.environ['AZURE_POSTGRESQL_USER'],
+        'PASSWORD': os.environ['AZURE_POSTGRESQL_PASSWORD'],
+        'PORT': os.environ.get('AZURE_POSTGRESQL_PORT', 5432),
+    }
+}

--- a/src/postgresql-secret-dotnet.cs
+++ b/src/postgresql-secret-dotnet.cs
@@ -1,0 +1,27 @@
+using System;
+using Npgsql;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        string connString = Environment.GetEnvironmentVariable("AZURE_POSTGRESQL_CONNECTIONSTRING");
+
+        using (var conn = new NpgsqlConnection(connString))
+        {
+            conn.Open();
+            using (var cmd = new NpgsqlCommand("SELECT * FROM your_table", conn))
+            {
+                using (var reader = cmd.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        Console.WriteLine(reader.GetString(0));
+                    }
+                }
+            }
+        }
+
+        Console.WriteLine("Connected successfully.");
+    }
+}

--- a/src/postgresql-secret-go.go
+++ b/src/postgresql-secret-go.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+    "database/sql"
+    "fmt"
+    "os"
+    _ "github.com/lib/pq"
+)
+
+func main() {
+    connStr := os.Getenv("AZURE_POSTGRESQL_CONNECTIONSTRING")
+    db, err := sql.Open("postgres", connStr)
+    if err != nil {
+        panic(err)
+    }
+    defer db.Close()
+
+    err = db.Ping()
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Println("Successfully connected!")
+}

--- a/src/postgresql-secret-java.java
+++ b/src/postgresql-secret-java.java
@@ -1,0 +1,17 @@
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+public class Main {
+    public static void main(String[] args) {
+        String connString = System.getenv("AZURE_POSTGRESQL_CONNECTIONSTRING");
+
+        try {
+            Connection conn = DriverManager.getConnection(connString);
+            System.out.println("Connected successfully.");
+        } catch (Exception e) {
+            System.err.println(e.getMessage());
+        }
+    }
+}

--- a/src/postgresql-secret-nodejs.js
+++ b/src/postgresql-secret-nodejs.js
@@ -1,0 +1,14 @@
+const { Client } = require('pg');
+
+const client = new Client({
+  user: process.env.AZURE_POSTGRESQL_USERNAME,
+  host: process.env.AZURE_POSTGRESQL_HOST,
+  database: process.env.AZURE_POSTGRESQL_DATABASE,
+  password: process.env.AZURE_POSTGRESQL_PASSWORD,
+  port: process.env.AZURE_POSTGRESQL_PORT,
+  ssl: process.env.AZURE_POSTGRESQL_SSL
+});
+
+client.connect();
+
+console.log('Connected successfully.');

--- a/src/postgresql-secret-php.php
+++ b/src/postgresql-secret-php.php
@@ -1,0 +1,16 @@
+<?php
+$dbconn = pg_connect(getenv('AZURE_POSTGRESQL_CONNECTIONSTRING'))
+    or die('Could not connect: ' . pg_last_error());
+
+$query = 'SELECT * FROM your_table';
+$result = pg_query($query) or die('Query failed: ' . pg_last_error());
+
+while ($line = pg_fetch_array($result, null, PGSQL_ASSOC)) {
+    echo $line['column1'] . "\t" . $line['column2'] . "\n";
+}
+
+pg_free_result($result);
+pg_close($dbconn);
+
+echo 'Connected successfully.';
+?>

--- a/src/postgresql-secret-python.py
+++ b/src/postgresql-secret-python.py
@@ -1,0 +1,17 @@
+import psycopg2
+import os
+
+conn = psycopg2.connect(os.environ['AZURE_POSTGRESQL_CONNECTIONSTRING'])
+
+cur = conn.cursor()
+cur.execute('SELECT * FROM your_table')
+
+rows = cur.fetchall()
+
+for row in rows:
+    print(row)
+
+cur.close()
+conn.close()
+
+print('Connected successfully.')

--- a/src/postgresql-secret-ruby.rb
+++ b/src/postgresql-secret-ruby.rb
@@ -1,0 +1,16 @@
+require 'pg'
+require 'uri'
+
+uri = URI.parse(ENV['AZURE_POSTGRESQL_CONNECTIONSTRING'])
+
+conn = PG.connect(
+  host: uri.host,
+  port: uri.port,
+  dbname: uri.path[1..-1],
+  user: uri.user,
+  password: uri.password
+)
+
+puts "Successfully connected!"
+
+conn.close

--- a/src/postgresql-secret-springboot.java
+++ b/src/postgresql-secret-springboot.java
@@ -1,0 +1,25 @@
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        // ServiceConnector set spring.data.url, spring.data.username, spring.data.password already
+        SpringApplication.run(Application.class, args);
+    }
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    public void run(String... args) throws Exception {
+        jdbcTemplate.query("SELECT * FROM your_table", rs -> {
+            while (rs.next()) {
+                System.out.println(rs.getString(1));
+            }
+        });
+
+        System.out.println("Connected successfully.");
+    }
+}

--- a/src/postgresql-systemassignedidentity-dotnet.cs
+++ b/src/postgresql-systemassignedidentity-dotnet.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+using Azure.Identity;
+using Npgsql;
+
+namespace ConsoleApp1
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            var connectionString = Environment.GetEnvironmentVariable("AZURE_POSTGRESQL_CONNECTIONSTRING");
+            var tokenCredential = new DefaultAzureCredential();
+            var accessToken = await tokenCredential.GetTokenAsync(new Azure.Core.TokenRequestContext(new[] { "https://ossrdbms-aad.database.windows.net/.default" }));
+            var builder = new NpgsqlConnectionStringBuilder(connectionString)
+            {
+                SslMode = SslMode.Require,
+                TrustServerCertificate = true,
+                IntegratedSecurity = true,
+                Username = new NpgsqlConnectionStringBuilder($"user=<{accessToken.Token}>").Username,
+                Password = new NpgsqlConnectionStringBuilder($"password=<{accessToken.Token}>").Password
+            };
+            using var conn = new NpgsqlConnection(builder.ConnectionString);
+            await conn.OpenAsync();
+            Console.WriteLine("Successfully connected!");
+        }
+    }
+}

--- a/src/postgresql-systemassignedidentity-java.java
+++ b/src/postgresql-systemassignedidentity-java.java
@@ -1,0 +1,23 @@
+import com.azure.identity.DefaultAzureCredential;
+import org.postgresql.ssl.NonValidatingFactory;
+import org.postgresql.util.PSQLException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class Main {
+    public static void main(String[] args) {
+        String connectionString = System.getenv("AZURE_POSTGRESQL_CONNECTIONSTRING");
+        
+        try {
+            DefaultAzureCredential tokenCredential = new DefaultAzureCredential();
+            String accessToken = tokenCredential.getToken("https://ossrdbms-aad.database.windows.net/.default").getToken();
+            String url = String.format("%s?sslfactory=org.postgresql.ssl.NonValidatingFactory&authenticationPluginClassName=com.azure.identity.extensions.jdbc.postgresql.AzurePostgresqlAuthenticationPlugin", connectionString);
+            Connection conn = DriverManager.getConnection(url, String.format("password=%s", accessToken));
+            System.out.println("Successfully connected!");
+            conn.close();
+        } catch (SQLException | PSQLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/postgresql-systemassignedidentity-springboot.java
+++ b/src/postgresql-systemassignedidentity-springboot.java
@@ -1,0 +1,27 @@
+import com.azure.identity.DefaultAzureCredential;
+import org.postgresql.ssl.NonValidatingFactory;
+import org.postgresql.util.PSQLException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+@SpringBootApplication
+public class Main {
+    public static void main(String[] args) {
+        SpringApplication.run(Main.class, args);
+    }
+
+    @Bean
+    public Connection getConnection(@Value("${spring.datasource.url}") String url, @Value("${spring.datasource.username}") String username) throws SQLException {
+        DefaultAzureCredential tokenCredential = new DefaultAzureCredential();
+        String accessToken = tokenCredential.getToken("https://ossrdbms-aad.database.windows.net/.default").getToken();
+        url = String.format("%s?&authenticationPluginClassName=com.azure.identity.extensions.jdbc.postgresql.AzurePostgresqlAuthenticationPlugin&sslfactory=org.postgresql.ssl.NonValidatingFactory", url);
+        Connection conn = DriverManager.getConnection(url, String.format("user=%s", username), String.format("password=%s", accessToken));
+        return conn;
+    }
+}

--- a/src/sqldatabase-secret-django.py
+++ b/src/sqldatabase-secret-django.py
@@ -1,0 +1,15 @@
+# settings.py
+import os
+
+DATABASES = {
+    "default": {
+        "ENGINE": "mssql",
+        "NAME": os.environ['AZURE_SQL_NAME'],
+        "USER": os.environ['AZURE_SQL_USER'],
+        "PASSWORD": os.environ['AZURE_SQL_PASSWORD'],
+        "HOST": os.environ['AZURE_SQL_HOST'],
+        "PORT": os.environ['AZURE_SQL_PORT'],
+        "OPTIONS": {"driver": "ODBC Driver 17 for SQL Server", 
+        },
+    },
+}

--- a/src/sqldatabase-secret-dotnet-connectionstring.cs
+++ b/src/sqldatabase-secret-dotnet-connectionstring.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Data.SqlClient;
+using System.Diagnostics;
+
+namespace ConsoleApp1
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            string connectionString = Environment.GetEnvironmentVariable("AZURE_SQL_CONNECTIONSTRING");
+
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connectionString);
+
+            using (SqlConnection connection = new SqlConnection(builder.ConnectionString))
+            {
+                connection.Open();
+                Console.WriteLine("Connected successfully.");
+                connection.Close();
+            }
+        }
+    }
+}

--- a/src/sqldatabase-secret-dotnet.cs
+++ b/src/sqldatabase-secret-dotnet.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Data.SqlClient;
+using System.Diagnostics;
+
+namespace ConsoleApp1
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            string connectionStr = Environment.GetEnvironmentVariable("AZURE_SQL_CONNECTIONSTRING");
+
+            SqlConnectionStringBuilder builder = new SqlConnectionStringBuilder(connectionString);
+
+            using (SqlConnection connection = new SqlConnection(builder.ConnectionString))
+            {
+                connection.Open();
+                Console.WriteLine("Connected successfully.");
+                connection.Close();
+            }
+        }
+    }
+}

--- a/src/sqldatabase-secret-go.go
+++ b/src/sqldatabase-secret-go.go
@@ -1,0 +1,16 @@
+import (
+    "database/sql"
+    "fmt"
+    _ "github.com/denisenkom/go-mssqldb"
+    "os"
+)
+
+func main() {
+    connString := os.Getenv("AZURE_SQL_CONNECTIONSTRING")
+    db, err := sql.Open("sqlserver", connString)
+    if err != nil {
+        fmt.Println("Error creating connection pool: ", err.Error())
+        os.Exit(1)
+    }
+    defer db.Close()
+}

--- a/src/sqldatabase-secret-java.java
+++ b/src/sqldatabase-secret-java.java
@@ -1,0 +1,15 @@
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public class Main {
+    public static void main(String[] args) {
+        String connectionString = System.getenv("AZURE_SQL_CONNECTIONSTRING");
+
+        try (Connection connection = DriverManager.getConnection(connectionString)) {
+            System.out.println("Connected successfully.");
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/sqldatabase-secret-nodejs.js
+++ b/src/sqldatabase-secret-nodejs.js
@@ -1,0 +1,28 @@
+
+const { Connection } = require('tedious');
+
+const config = {
+  authentication: {
+    options: {
+      userName: process.env.AZURE_SQL_USERNAME,
+      password: process.env.AZURE_SQL_PASSWORD,
+    },
+    type: 'default',
+  },
+  server: process.env.AZURE_SQL_SERVER,
+  options: {
+    database: process.env.AZURE_SQL_DATABASE,
+    port: process.env.AZURE_SQL_PORT,
+    encrypt: true,
+  },
+};
+
+const connection = new Connection(config);
+
+connection.on('connect', (err) => {
+  if (err) {
+    console.error(err.message);
+  } else {
+    console.log('Connected successfully.');
+  }
+});

--- a/src/sqldatabase-secret-php.php
+++ b/src/sqldatabase-secret-php.php
@@ -1,0 +1,21 @@
+<?php
+
+$connectionString = sprintf("sqlsrv:server = tcp:%s.database.windows.net,1433; Database = %s", 
+    getenv("AZURE_SQL_SERVERNAME"), 
+    getenv("AZURE_SQL_DATABASE"));
+
+$connectionOptions = array(
+    "Uid" => getenv("AZURE_SQL_UID"), 
+    "PWD" => getenv("AZURE_SQL_PASSWORD"), 
+    "Encrypt" => 1,
+    "TrustServerCertificate" => 0
+);
+
+try {
+    $conn = new PDO($connectionString, $connectionOptions);
+    $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    echo "Connected successfully.";
+} catch (PDOException $e) {
+    print("Error connecting to SQL Server.");
+    die(print_r($e));
+}

--- a/src/sqldatabase-secret-python.py
+++ b/src/sqldatabase-secret-python.py
@@ -1,0 +1,14 @@
+import pyodbc
+import os
+
+connection_string = 'Driver={ODBC Driver 17 for SQL Server};Server=tcp:' \
+    + os.environ['AZURE_SQL_SERVERNAME'] + '.database.windows.net,1433;Database=' \
+    + os.environ['AZURE_SQL_DATABASE'] + ';Uid=' + os.environ['AZURE_SQL_UID'] \
+    + ';Pwd=' + os.environ['AZURE_SQL_PASSWORD'] + ';Encrypt=yes;TrustServerCertificate=no;Connection Timeout=30;'
+
+try:
+    with pyodbc.connect(connection_string) as connection:
+        print("Connected successfully.")
+except pyodbc.Error as e:
+    print("Error connecting to SQL Server.")
+    print(e)

--- a/src/sqldatabase-secret-ruby.rb
+++ b/src/sqldatabase-secret-ruby.rb
@@ -1,0 +1,15 @@
+require 'tiny_tds'
+
+client = TinyTds::Client.new(
+  username: ENV['AZURE_SQL_USERNAME'],
+  password: ENV['AZURE_SQL_PASSWORD'],
+  host: ENV['AZURE_SQL_HOST'],
+  port: ENV['AZURE_SQL_PORT'],
+  database: ENV['AZURE_SQL_DATABASE']
+)
+
+if client.active?
+  puts "Connected successfully."
+else
+  puts "Error connecting to SQL Server."
+end

--- a/src/sqldatabase-secret-springboot.java
+++ b/src/sqldatabase-secret-springboot.java
@@ -1,0 +1,10 @@
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Main {
+    public static void main(String[] args) {
+        /* ServiceConnector set below properties: spring.datasource.url, spring.datasource.username, spring.datasource.password */
+        SpringApplication.run(Main.class, args);
+    }
+}

--- a/src/sqldatabase-systemidentity-dotnet-connectionstring.cs
+++ b/src/sqldatabase-systemidentity-dotnet-connectionstring.cs
@@ -1,0 +1,19 @@
+using System.Data.SqlClient;
+using System;
+
+namespace ConsoleApp1
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            string connString = Environment.GetEnvironmentVariable("AZURE_SQL_CONNECTIONSTRING");
+
+            using (SqlConnection connection = new SqlConnection(connString))
+            {
+                connection.Open();
+                Console.WriteLine("Connected successfully.");
+            }
+        }
+    }
+}

--- a/src/sqldatabase-systemidentity-dotnet.cs
+++ b/src/sqldatabase-systemidentity-dotnet.cs
@@ -1,0 +1,19 @@
+using System.Data.SqlClient;
+using System;
+
+namespace ConsoleApp1
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            string connString = Environment.GetEnvironmentVariable("AZURE_SQL_CONNECTIONSTRING");
+
+            using (SqlConnection connection = new SqlConnection(connString))
+            {
+                connection.Open();
+                Console.WriteLine("Connected successfully.");
+            }
+        }
+    }
+}

--- a/src/sqldatabase-systemidentity-java.java
+++ b/src/sqldatabase-systemidentity-java.java
@@ -1,0 +1,16 @@
+import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class Main {
+    public static void main(String[] args) throws SQLException {
+        String connString = System.getenv("AZURE_SQL_CONNECTIONSTRING");
+
+        SQLServerDataSource ds = new SQLServerDataSource();
+        ds.setURL(connString);
+
+        try (Connection con = ds.getConnection()) {
+            System.out.println("Connected successfully.");
+        }
+    }
+}

--- a/src/sqldatabase-systemidentity-nodejs.js
+++ b/src/sqldatabase-systemidentity-nodejs.js
@@ -1,0 +1,25 @@
+const sql = require('mssql');
+
+async function main() {
+    const host = process.env.AZURE_SQL_SERVER;
+    const database = process.env.AZURE_SQL_DATABASE;
+    const username = process.env.AZURE_SQL_USERNAME;
+    const password = process.env.AZURE_SQL_PASSWORD;
+    const port = process.env.AZURE_SQL_PORT;
+    const authType = process.env.AZURE_SQL_AUTHENTICATIONTYPE;
+
+    const pool = await sql.connect({
+        server: host,
+        database: database,
+        user: username,
+        password: password,
+        port: port,
+        authentication: {
+            type: authType
+        }
+    });
+
+    console.log('Connected successfully.');
+}
+
+main().catch(err => console.error(err));

--- a/src/sqldatabase-systemidentity-python.py
+++ b/src/sqldatabase-systemidentity-python.py
@@ -1,0 +1,19 @@
+import pyodbc
+import os
+
+host = os.environ['AZURE_SQL_HOST']
+database = os.environ['AZURE_SQL_DATABASE']
+username = os.environ['AZURE_SQL_USERNAME']
+password = os.environ['AZURE_SQL_PASSWORD']
+authtype = os.environ['AZURE_SQL_AUTHENTICATION']
+
+conn = pyodbc.connect(
+    'DRIVER={ODBC Driver 17 for SQL Server};'
+    f'SERVER={host};'
+    f'DATABASE={database};'
+    f'UID={username};'
+    f'PWD={password};'
+    'Authentication={authtype};'
+)
+
+print('Connected successfully.')

--- a/src/sqldatabase-systemidentity-springboot.java
+++ b/src/sqldatabase-systemidentity-springboot.java
@@ -1,0 +1,19 @@
+import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class DataSourceConfig {
+    @Bean
+    public DataSource dataSource(DataSourceProperties properties) {
+        String connString = System.getenv("AZURE_SQL_CONNECTIONSTRING");
+
+        SQLServerDataSource ds = new SQLServerDataSource();
+        ds.setURL(connString);
+
+        return ds;
+    }
+}


### PR DESCRIPTION
## Description
sample file naming convention is
```
<target>-<authType>-<clientType>.language_file_extension.
```

At portal, will construct the sample file github url based on the naming convention.
- If github file with convention name not found,  will fall back to clientType python.
- If github file with python still not found, will fall back to root folder of the github repo

https://msazure.visualstudio.com/One/_git/ServiceLinker-PortalExtension?path=/src/Default/ServiceLinkerExtension/Client/React/Shared/SampleHelper.ts&_a=contents&version=GBmaster

